### PR TITLE
Allow version 40 or 41 or 41.1 but not 42

### DIFF
--- a/gnome-shell-extension-impatience-git/.SRCINFO
+++ b/gnome-shell-extension-impatience-git/.SRCINFO
@@ -1,6 +1,6 @@
 pkgbase = gnome-shell-extension-impatience-git
 	pkgdesc = speed up gnome-shell animations
-	pkgver = r43.e8e132f
+	pkgver = r45.9d48e4d
 	pkgrel = 1
 	url = https://github.com/gfxmonk/gnome-shell-impatience
 	install = gschemas.install

--- a/gnome-shell-extension-impatience-git/.SRCINFO
+++ b/gnome-shell-extension-impatience-git/.SRCINFO
@@ -8,7 +8,7 @@ pkgbase = gnome-shell-extension-impatience-git
 	license = GPL3
 	makedepends = git
 	depends = gnome-shell>=1:40
-	depends = gnome-shell<1:41
+	depends = gnome-shell<1:42
 	source = git+https://github.com/gfxmonk/gnome-shell-impatience
 	sha256sums = SKIP
 

--- a/gnome-shell-extension-impatience-git/PKGBUILD
+++ b/gnome-shell-extension-impatience-git/PKGBUILD
@@ -7,7 +7,7 @@ pkgdesc="speed up gnome-shell animations"
 arch=('any')
 url="https://github.com/gfxmonk/gnome-shell-impatience"
 license=('GPL3')
-depends=('gnome-shell>=1:40' 'gnome-shell<1:41')
+depends=('gnome-shell>=1:40' 'gnome-shell<1:42')
 makedepends=('git')
 install='gschemas.install'
 source=("git+https://github.com/gfxmonk/gnome-shell-impatience")

--- a/gnome-shell-extension-impatience-git/PKGBUILD
+++ b/gnome-shell-extension-impatience-git/PKGBUILD
@@ -1,7 +1,7 @@
 # Maintainer: Michael Schubert <mschu.dev at gmail> github.com/mschubert/PKGBUILDs
 pkgname=gnome-shell-extension-impatience-git
 _pkgname=gnome-shell-impatience
-pkgver=r43.e8e132f
+pkgver=r45.9d48e4d
 pkgrel=1
 pkgdesc="speed up gnome-shell animations"
 arch=('any')


### PR DESCRIPTION
The previous only allowed 40 but upstream supports 41. Bump forward to 41. 

https://github.com/timbertson/gnome-shell-impatience/issues/25